### PR TITLE
fix "command not found" when running with flags

### DIFF
--- a/prep
+++ b/prep
@@ -40,4 +40,10 @@ did(){
   read -p "Enter links count('a' for day complete) : " count
 }
 
-$@
+for arg in $@
+do
+ if [[ $arg == "day" || $arg  == "start" || $arg == "did" ]]
+then 
+    $@
+fi
+done


### PR DESCRIPTION
Fixes this error

./prep  :  line 43:  -p:  command not found

When running prep with flags i.e -p/--progress/progress, -h